### PR TITLE
Fixed video editing logic

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -285,10 +285,12 @@ $app->group('/admin/channels/{slug}', function () {
             $listing->setDescription($parsedBody['description']);
             $listingRepository->persist($listing);
 
-            $videoProxyService = $this->getContainer()->get('tvlistings.video_proxy.service');
-            $videoProxyUuid = $videoProxyService->createFromSource($parsedBody['video_source']);
-            $listing->changeResourceLink($videoProxyUuid);
-            $listingRepository->persist($listing);
+            if ($parsedBody['video_source']) {
+                $videoProxyService = $this->getContainer()->get('tvlistings.video_proxy.service');
+                $videoProxyUuid = $videoProxyService->createFromSource($parsedBody['video_source']);
+                $listing->changeResourceLink($videoProxyUuid);
+                $listingRepository->persist($listing);
+            }
 
             $uri = $this->router->pathFor(
                 'admin_channel_show',
@@ -376,14 +378,15 @@ $app->group('/admin/listings/{id}', function () {
             $listing->changeTitle($parsedBody['title']);
             $listing->changeProgramDate(new \DateTime($parsedBody['programDate']));
             $listing->programAt($parsedBody['programAt']);
-            $listing->changeResourceLink($parsedBody['resourceLink']);
             $listing->setDescription($parsedBody['description']);
             $listingRepository->persist($listing);
 
-            $videoProxyService = $this->getContainer()->get('tvlistings.video_proxy.service');
-            $videoProxyUuid = $videoProxyService->createFromSource($parsedBody['video_source']);
-            $listing->changeResourceLink($videoProxyUuid);
-            $listingRepository->persist($listing);
+            if ($parsedBody['video_source']) {
+                $videoProxyService = $this->getContainer()->get('tvlistings.video_proxy.service');
+                $videoProxyUuid = $videoProxyService->createFromSource($parsedBody['video_source']);
+                $listing->changeResourceLink($videoProxyUuid);
+                $listingRepository->persist($listing);
+            }
 
             $uri = $this->router->pathFor(
                 'admin_channel_show',

--- a/src/Domain/Entity/VideoProxy.php
+++ b/src/Domain/Entity/VideoProxy.php
@@ -27,6 +27,10 @@ class VideoProxy
      */
     public function __construct($source)
     {
+        if (null === $source || "" === $source) {
+            throw new \InvalidArgumentException("Video source shouldn't be empty.");
+        }
+
         $this->source = $source;
         $this->uuid = Uuid::uuid4();
     }

--- a/tests/unit/Entity/VideoProxyTest.php
+++ b/tests/unit/Entity/VideoProxyTest.php
@@ -17,4 +17,23 @@ class VideoProxyTest extends \PHPUnit_Framework_TestCase
        $this->assertEquals("http://videolink", $videoProxy->getSource());
        $this->assertTrue(Uuid::isValid($videoProxy->getUuid()));
     }
+
+    /**
+     * @test
+     * @dataProvider invalidSourceProvider
+     * @expectedException \InvalidArgumentException
+     */
+    public function it_should_be_created_with_empty_video_source($source)
+    {
+       $videoProxy = new VideoProxy($source);
+    }
+
+    public function invalidSourceProvider()
+    {
+        return array(
+            array(''),
+            array(null),
+            array(""),
+        );
+    }
 }


### PR DESCRIPTION
When there's no video link on edit page, listing shouldn't be updated
with empty video source.
